### PR TITLE
Correct CStruct repr version check

### DIFF
--- a/lib/MoarVM/Guts/REPRs.pm6
+++ b/lib/MoarVM/Guts/REPRs.pm6
@@ -57,7 +57,7 @@ my class CStructB is repr('CStruct') {
 my %known-bodies = (
     VMArray => MVMArrayB,
     CArray => CArrayB,
-    CStruct => $*VM.version >= v2018.12.*+ ?? CStructB !! OldCStructB
+    CStruct => $*VM.version > v2018.12 ?? CStructB !! OldCStructB
 );
 
 sub OBJECT_BODY(Mu \any) is export {


### PR DESCRIPTION
MoarVM 2018.12 did not have the new repr. The next release presumably will.
`v2018.12 >= v2018.12.*+` returns True and thus NativeHelpers-Blob broke on MoarVM 2018.12. This PR fixes that.
I am not entirely sure what the `.*+` was intended to do, so I'd be grateful for a second look by whomever merges this request.